### PR TITLE
Replicaset pretty log 1761202

### DIFF
--- a/replicaset.go
+++ b/replicaset.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/utils"
-	"github.com/kr/pretty"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -54,7 +53,7 @@ var (
 func attemptInitiate(monotonicSession *mgo.Session, cfg []Config) error {
 	var err error
 	for _, c := range cfg {
-		logger.Infof("Initiating replicaset with config %#v", c)
+		logger.Infof("Initiating replicaset with config: %s", fmtConfigForLog(&c))
 		if err = monotonicSession.Run(bson.D{{"replSetInitiate", c}}, nil); err != nil {
 			logger.Infof("Unsuccessful attempt to initiate replicaset: %v", err)
 			continue
@@ -187,9 +186,8 @@ func fmtConfigForLog(config *Config) string {
 // connection to be dropped. If so, it Refreshes the session and tries to Ping
 // again.
 func applyReplSetConfig(cmd string, session *mgo.Session, oldconfig, newconfig *Config) error {
-	logger.Debugf("%s() changing replica set\nfrom %s\n  to %s\ndiff:\n%s",
-		cmd, fmtConfigForLog(oldconfig), fmtConfigForLog(newconfig),
-		strings.Join(pretty.Diff(oldconfig, newconfig), "\n"))
+	logger.Debugf("%s() changing replica set\nfrom %s\n  to %s",
+		cmd, fmtConfigForLog(oldconfig), fmtConfigForLog(newconfig))
 
 	buildInfo, err := session.BuildInfo()
 	if err != nil {

--- a/replicaset.go
+++ b/replicaset.go
@@ -186,7 +186,7 @@ func fmtConfigForLog(config *Config) string {
 // connection to be dropped. If so, it Refreshes the session and tries to Ping
 // again.
 func applyReplSetConfig(cmd string, session *mgo.Session, oldconfig, newconfig *Config) error {
-	logger.Debugf("%s() changing replica set\nfrom %s\n  to %s",
+	logger.Debugf("%s() changing replica set\nfrom %s\nto %s",
 		cmd, fmtConfigForLog(oldconfig), fmtConfigForLog(newconfig))
 
 	buildInfo, err := session.BuildInfo()

--- a/replicaset_test.go
+++ b/replicaset_test.go
@@ -771,16 +771,16 @@ func (s *fmtConfigForLogSuite) TestSimpleFormatting(c *gc.C) {
     {3 "192.168.0.27:37017" juju-machine-id:2 not-voting},
   },
 }`)
-	// Side effect, the config is sorted:
-	c.Check(cfg.Members[0].Id, gc.Equals, 1)
-	c.Check(cfg.Members[1].Id, gc.Equals, 2)
+	// no side effect, the config is not sorted:
+	c.Check(cfg.Members[0].Id, gc.Equals, 2)
+	c.Check(cfg.Members[1].Id, gc.Equals, 1)
 	c.Check(cfg.Members[2].Id, gc.Equals, 3)
 	cfg2 := &Config{
 		Name:    "juju",
 		Version: 2,
 		Members: append([]Member(nil), cfg.Members...),
 	}
-	cfg2.Members[0].Votes = anInt(0)
+	cfg2.Members[1].Votes = anInt(0)
 	cfg2.Members[2].Votes = anInt(1)
 	c.Check(fmtConfigForLog(cfg2), gc.Equals, `{
   Name: juju,

--- a/replicaset_test.go
+++ b/replicaset_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils"
-	"github.com/kr/pretty"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/mgo.v2"
 )
@@ -786,8 +785,4 @@ func (s *fmtConfigForLogSuite) TestSimpleFormatting(c *gc.C) {
     {3 "192.168.0.27:37017" juju-machine-id:2 voting},
   },
 }`)
-	out := pretty.Diff(cfg, cfg2)
-	c.Check(strings.Join(out, "\n"), gc.Equals, `Version: 1 != 2
-Members[0].Votes: nil != &int(0)
-Members[2].Votes: 0 != 1`)
 }

--- a/replicaset_test.go
+++ b/replicaset_test.go
@@ -725,3 +725,44 @@ func (s *MongoIPV6Suite) TestAddressFixing(c *gc.C) {
 	c.Check(result.PrimaryAddress, gc.Equals, ipv6GetAddr(root))
 	c.Check(result.Addresses, jc.DeepEquals, []string{ipv6GetAddr(root)})
 }
+
+type fmtConfigForLogSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&fmtConfigForLogSuite{})
+
+func (s *fmtConfigForLogSuite) TestSimpleFormatting(c *gc.C) {
+	anInt := func(v int) *int {
+		return &v
+	}
+	cfg := &Config{
+		Name: "juju",
+		Version: 1,
+		Members: []Member{{
+			Id: 2,
+			Address: "192.168.0.10:37017",
+			Tags: map[string]string{"juju-machine-id": "1"},
+			Votes: anInt(1),
+		}, {
+			Id: 1,
+			Address: "192.168.0.9:37017",
+			Tags: map[string]string{"juju-machine-id": "0"},
+			Votes: nil,
+		}, {
+			Id: 3,
+			Address: "192.168.0.27:37017",
+			Tags: map[string]string{"juju-machine-id": "2"},
+			Votes: anInt(0),
+		}},
+	}
+	c.Check(fmtConfigForLog(cfg), gc.Equals, `{
+  Name: juju,
+  Version: 1,
+  Members: {
+    {1 "192.168.0.9:37017" juju-machine-id:0 voting},
+    {2 "192.168.0.10:37017" juju-machine-id:1 voting},
+    {3 "192.168.0.27:37017" juju-machine-id:2 not-voting},
+  },
+}`)
+}


### PR DESCRIPTION
Prettier log messages so that it is more understandable to humans what is going on.

1. Continually sort config.Members (using sort.Stable means it should do a single pass over already sorted data). But this means that when showing the output the "Id" values are kept in sorted order, so one config isn't displayed as 1,2,3, and the other as 1,3,2 making it much harder to visually compare.
2. Tweak fmtConfigForLog so that it doesn't try to squeeze the whole structure onto a single line
3. Include whether on not the Member is considered 'voting'. It was missed in the log output before.
4. I tested using kr/pretty.Diff, but it didn't give very helpful output. If we had a 'unified diff' that we were using, we could probably run it on the textual format, and get a pretty nice diff. But I don't think we have a standard one.

The formatting of new members changed from something like:
```
machine-0: 18:08:29 DEBUG juju.replicaset Set() changing replica set
from {Name: juju, Version: 10, Members: {Member{2 "10.16.17.4:37017" map[juju-machine-id:2]}, Member{1 "10.16.17.189:37017" map[juju-machine-id:0]}, Member{3 "10.16.17.165:37017" map[juju-machine-id:3]}}}
  to {Name: juju, Version: 11, Members: {Member{3 "10.16.17.165:37017" map[juju-machine-id:3]}, Member{2 "10.16.17.4:37017" map[juju-machine-id:2]}, Member{1 "10.16.17.189:37017" map[juju-machine-id:0]}}}
```
To something like:
```
machine-2: 13:11:03 DEBUG juju.replicaset Set() changing replica set
from {
  Name: juju,
  Version: 1,
  Members: {
    {1 "10.16.17.189:37017" juju-machine-id:0 voting},
  },
}
to {
  Name: juju,
  Version: 2,
  Members: {
    {1 "10.16.17.189:37017" juju-machine-id:0 voting},
    {2 "10.16.17.8:37017" juju-machine-id:1 not-voting},
    {3 "10.16.17.224:37017" juju-machine-id:2 not-voting},
  },
}
```
and
```
machine-2: 13:12:03 DEBUG juju.replicaset Set() changing replica set
from {
  Name: juju,
  Version: 2,
  Members: {
    {1 "10.16.17.189:37017" juju-machine-id:0 voting},
    {2 "10.16.17.8:37017" juju-machine-id:1 not-voting},
    {3 "10.16.17.224:37017" juju-machine-id:2 not-voting},
  },
}
to {
  Name: juju,
  Version: 3,
  Members: {
    {1 "10.16.17.189:37017" juju-machine-id:0 voting},
    {2 "10.16.17.8:37017" juju-machine-id:1 voting},
    {3 "10.16.17.224:37017" juju-machine-id:2 voting},
  },
}
```

Also the initialization step changed from
```
[LOG] 0:04.100 INFO juju.replicaset Initiating replicaset with config: replicaset.Config{Name:"juju", Version:1, Members:[]replicaset.Member{replicaset.Member{Id:1, Address:"localhost:38134", Priority:(*float64)(nil), Tags:map[string]string{"foo":"bar"}, Votes:(*int)(nil)}}}
```
to
```
[LOG] 0:04.079 INFO juju.replicaset Initiating replicaset with config: {
  Name: juju,
  Version: 1,
  Members: {
    {1 "localhost:45983" foo:bar voting},
  },
}
```
https://bugs.launchpad.net/juju/+bug/1761202