### PR TITLE
protocolVersion is mandatory as version 0 is deprecated starting from MongoDB 4

### DIFF
--- a/replicaset.go
+++ b/replicaset.go
@@ -193,11 +193,12 @@ func fmtConfigForLog(config *Config) string {
 	}
 	return fmt.Sprintf(`{
   Name: %s,
+  ProtocolVersion: %d,
   Version: %d,
   Members: {
 %s
   },
-}`, config.Name, config.Version, strings.Join(memberInfo, "\n"))
+}`, config.Name, config.ProtocolVersion, config.Version, strings.Join(memberInfo, "\n"))
 }
 
 // applyReplSetConfig applies the new config to the mongo session. It also logs
@@ -439,9 +440,10 @@ func currentConfig(session *mgo.Session) (*Config, error) {
 // Config is the document stored in mongodb that defines the servers in the
 // replica set
 type Config struct {
-	Name    string   `bson:"_id"`
-	Version int      `bson:"version"`
-	Members []Member `bson:"members"`
+	Name            string   `bson:"_id"`
+	ProtocolVersion int64    `bson:"protocolVersion,omitempty"`
+	Version         int      `bson:"version"`
+	Members         []Member `bson:"members"`
 }
 
 // StepDownPrimary asks the current mongo primary to step down.


### PR DESCRIPTION
Without this field, trying to call `juju/replicaset.Add(...)` returns the error:

```
Support for replication protocol version 0 was removed in MongoDB 4.0. Downgrade to MongoDB version 3.6 and upgrade your protocol version to 1 before upgrading your MongoDB version
```

With this (https://github.com/juju/replicaset/pull/11/files#diff-e46274b947a43dc00cb44a2b74050796R86) and this (https://github.com/juju/replicaset/pull/11/files#diff-e46274b947a43dc00cb44a2b74050796R96) line, it requires MongoDB 3.2 as the protocol version 1 has been introduced in 3.2. Let me know if it's acceptable for you.